### PR TITLE
Change extension name to fix web store violation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-  "name": "New Google Books",
-  "version": "1.2.0",
+  "name": "Unofficial New Google Books Interface",
+  "version": "1.2.1",
   "manifest_version": 3,
-  "description": "Automatically redirects to the new design of Google Books.",
+  "description": "Automatically redirects to the new interface of Google Books. This extension is not an official product.",
   "homepage_url": "https://github.com/lcookiel/newgooglebooks",
   "icons": {
     "16": "images/16.png",


### PR DESCRIPTION
This pull request changes the name of the extension in manifest.json file to comply with Chrome Web Store terms. The following violation was the reason for the rejection in Web Store:

Violation reference ID: Red Nickel
Violation: Impersonating or mimicking the following entity through item’s metadata/UI

This pull request also updates extension version in manifest.json from 1.2.0 to 1.2.1 and explicitly adds to the description the disclaimer that the extension is not an official product.