### PR TITLE
Improve URL handling to prevent constructor errors

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -6,14 +6,17 @@ chrome.tabs.onUpdated.addListener(function () {
     function (tabs) {
       var currenturl = tabs[0].url;
       var googlebooksmatch = RegExp("(?:https?:\/\/)?(?:www.)?books.google.[a-zA-Z]*").test(currenturl);
-      var url = new URL(currenturl);
-      var args = new URLSearchParams(url.search);
-      var id = args.get('id');
-      if (googlebooksmatch && id != null) {
-        var newurl = "https://www.google.com/books/edition/_/" + id;
-        chrome.tabs.update(null, {
-          url: newurl
-        });
-      };
+
+      if (googlebooksmatch) {
+        var url = new URL(currenturl);
+        var args = new URLSearchParams(url.search);
+        var id = args.get('id');
+        if (id != null) {
+          var newurl = "https://www.google.com/books/edition/_/" + id;
+          chrome.tabs.update(null, {
+            url: newurl
+          });
+        };
+      }
     });
 });


### PR DESCRIPTION
**Description:**

- This pull request addresses an issue encountered when constructing a URL object with an invalid URL in the background.js. The changes made ensure that the URL constructor is only called when the current URL matches the Google Books URL pattern, preventing the "TypeError: Failed to construct 'URL': Invalid URL at..." error.

**Changes:**

- Moved the URL object creation and subsequent code inside a conditional block that checks if the current URL matches the Google Books pattern.
- This ensures that the URL constructor is only called for valid Google Books URLs, preventing the error from occurring.

**Testing:**

- Tested the extension with various Google Books URLs to ensure that the intended redirection still works as expected.
- Tested with non-Google Books URLs (including hidden Chrome URLs, e.g., chrome://extensions) to verify that the error is no longer encountered.
